### PR TITLE
Preventing "Something went wrong" error

### DIFF
--- a/galaxy.js
+++ b/galaxy.js
@@ -262,14 +262,6 @@
   const bgImage = bgContainer.children[0].children[0];
   document.body.prepend(bgContainer);
 
-  // move user profile icon to navbar
-  waitForElement([".main-userWidget-box"], ([profMenu]) => {
-    const header = profMenu.parentElement;
-    const dest = document.querySelector(".main-navBar-navBar");
-    header.removeChild(profMenu);
-    dest.append(profMenu);
-  });
-
   // add fade and dimness effects to mainview scroll node
   waitForElement([".Root__main-view .os-viewport.os-viewport-native-scrollbars-invisible"], ([scrollNode]) => {
     scrollNode.addEventListener("scroll", () => {


### PR DESCRIPTION
Removing the "Move user profile icon to navbar" feature (line 265-271) will prevent the "Something went wrong error" when selecting a searched artist or jumping between pages.