### PR TITLE
fix: improved position of jukebox stats

### DIFF
--- a/user.css
+++ b/user.css
@@ -1034,3 +1034,8 @@ THIRD PARTY EXTENSIONS/APPS
 .login-button {
     color: black !important;
 }
+
+/*The Eternal Jukebox*/
+.app-module__stats___LylvR_eternalDjukebox {
+    padding-bottom: 110px;
+}


### PR DESCRIPTION
Changed the position of the Eternal Jukebox stats so that the scroll fade and dim doesn't affect its viewability.