### PR TITLE
fix: blank reset button in jukebox settings

### DIFF
--- a/user.css
+++ b/user.css
@@ -1039,3 +1039,7 @@ THIRD PARTY EXTENSIONS/APPS
 .app-module__flex-center___p5IEY_eternalDjukebox button {
     color: black;
 }
+
+.app-module__flex-center___p5IEY_eternalDjukebox {
+    padding-bottom: 12px;
+}

--- a/user.css
+++ b/user.css
@@ -1034,3 +1034,8 @@ THIRD PARTY EXTENSIONS/APPS
 .login-button {
     color: black !important;
 }
+
+/*The Eternal Jukebox*/
+.app-module__flex-center___p5IEY_eternalDjukebox button {
+    color: black;
+}


### PR DESCRIPTION
This makes the "Reset" button in the Eternal Jukebox settings visible.

The issue was caused by the background colour and text colour being the same.